### PR TITLE
ANDROID-15781 Fail in case plugin is applied before app/library plugin and fix issues with file overwriting in emulators.

### DIFF
--- a/include-build/gradle-plugin/src/main/java/com/telefonica/loggerazzi/LoggerazziNoDeviceProviderInstrumentTestTasksException.kt
+++ b/include-build/gradle-plugin/src/main/java/com/telefonica/loggerazzi/LoggerazziNoDeviceProviderInstrumentTestTasksException.kt
@@ -1,0 +1,5 @@
+package com.telefonica.loggerazzi
+
+class LoggerazziNoDeviceProviderInstrumentTestTasksException : Exception(
+    "No device provider instrument test tasks found. Make sure you are applying the Loggerazzi plugin after the Android app/library plugin."
+)

--- a/include-build/gradle-plugin/src/main/java/com/telefonica/loggerazzi/LoggerazziReportConst.kt
+++ b/include-build/gradle-plugin/src/main/java/com/telefonica/loggerazzi/LoggerazziReportConst.kt
@@ -87,12 +87,6 @@ REPORT_TEMPLATE_BODY
     </div>
 </div>
 
-<div id="imageBottomSheet" class="modal bottom-sheet max-height">
-    <div class="modal-content center-align">
-        <img id="modalImage" src="" alt="">
-    </div>
-</div>
-
 <footer class="page-footer orange">
     <div class="container">
         <a class="us" href="https://github.com/Telefonica/loggerazzi" target="_blank"


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-15781](https://jira.tid.es/browse/ANDROID-15781)

### :goal_net: What's the goal?
With this PR i'm solving two issues:

1. In cases where loggerazzi plugin was applied before the android application/library plugin, plugin tasks were not executed. 
2. In case a test is executed without a previous emulator files cleanup, test app won't be available to overwrite any previously generated files. (This is done by loggerazzi plugin before all tests execution, but can happen also in cases like test retries)

### :construction: How do we do it?
* Now, Loggerazzi will fail in configuration time if no instrumentation tasks are found for the project where it is added.
* Loggerazzi writes in the "Download" public directory, as public directories are the only places where the generated files live after the test execution. Apps can create files in public directories but cannot delete/overwrite them, these was being controlled by the loggerazzi plugin before test execution, removing any previous files in the emulator, but there are some cases (like test retries) where the plugin cannot interfere to delete previous generated files. So, i'm changing the behavior to always generate a new file with a timestamp appended to the end of the file name, so, when the loggerazzi plugin pulls all files, it filters by the most recent generated files for each test case, generating proper filenames for reports and baseline updates.

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
- [x] Tested with Latch project