### PR TITLE
ANDROID-15807 Add @IgnoreLoggerazzi annotation to ignore a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,3 +136,6 @@ class FakeAnalyticsTracker : AnalyticsTracker, LogsRecorder<String> {
 By default, Loggerazzi rule compares recorded logs by ensuring these are equal and in same order than the baseline logs.
 
 In case a different comparation mechanism is needed (such as ignoring the order of the events, or ignoring certain logs), you can implement an specific [LogComparator](loggerazzi/src/main/java/com/telefonica/loggerazzi/LogComparator.kt), which can be provided to the LoggerazziRule on its creation.
+
+### Ignore a test
+If you want to ignore a test from Loggerazzi verification, you can use the `@IgnoreLoggerazzi` annotation in your test.

--- a/app/src/androidTest/java/com/telefonica/loggerazzi/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/telefonica/loggerazzi/ExampleInstrumentedTest.kt
@@ -39,6 +39,12 @@ class ExampleInstrumentedTest {
     fun testEmpty() {
         // Empty, just to test empty logs comparation.
     }
+
+    @Test
+    @IgnoreLoggerazzi
+    fun testIgnoreLoggerazzi() {
+        recorder.record("My log")
+    }
 }
 
 class FakeTestRecorder: LogsRecorder<String> {

--- a/app/src/androidTest/java/com/telefonica/loggerazzi/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/telefonica/loggerazzi/ExampleInstrumentedTest.kt
@@ -45,6 +45,12 @@ class ExampleInstrumentedTest {
     fun testIgnoreLoggerazzi() {
         recorder.record("My log")
     }
+
+    @Test
+    @IgnoreLoggerazzi
+    fun testIgnoreLoggerazziWithoutGoldenFile() {
+        recorder.record("My log")
+    }
 }
 
 class FakeTestRecorder: LogsRecorder<String> {

--- a/app/src/androidTestDebug/assets/loggerazzi-golden-files/com.telefonica.loggerazzi.ExampleInstrumentedTest_testIgnoreLoggerazzi.txt
+++ b/app/src/androidTestDebug/assets/loggerazzi-golden-files/com.telefonica.loggerazzi.ExampleInstrumentedTest_testIgnoreLoggerazzi.txt
@@ -1,0 +1,2 @@
+My log
+My second log

--- a/loggerazzi/src/main/java/com/telefonica/loggerazzi/IgnoreLoggerazzi.kt
+++ b/loggerazzi/src/main/java/com/telefonica/loggerazzi/IgnoreLoggerazzi.kt
@@ -1,0 +1,6 @@
+package com.telefonica.loggerazzi
+
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.FUNCTION)
+annotation class IgnoreLoggerazzi

--- a/loggerazzi/src/main/java/com/telefonica/loggerazzi/LoggerazziRule.kt
+++ b/loggerazzi/src/main/java/com/telefonica/loggerazzi/LoggerazziRule.kt
@@ -9,7 +9,7 @@ import java.io.File
 class LoggerazziRule(
     recorder: LogsRecorder<String>,
     comparator: LogComparator<String> = DefaultLogComparator(),
-): GenericLoggerazziRule<String>(
+) : GenericLoggerazziRule<String>(
     recorder = recorder,
     stringMapper = object : StringMapper<String> {
         override fun fromLog(log: String): String = log
@@ -17,6 +17,7 @@ class LoggerazziRule(
     },
     comparator = comparator,
 )
+
 open class GenericLoggerazziRule<LogType>(
     val recorder: LogsRecorder<LogType>,
     private val stringMapper: StringMapper<LogType>,
@@ -47,6 +48,8 @@ open class GenericLoggerazziRule<LogType>(
     override fun succeeded(description: Description?) {
         super.succeeded(description)
 
+        val isTestIgnored = description?.getAnnotation(IgnoreLoggerazzi::class.java) != null
+
         val testName = "${description?.className}_${description?.methodName}"
         val fileName = "${testName}.${System.nanoTime()}"
 
@@ -56,7 +59,7 @@ open class GenericLoggerazziRule<LogType>(
         testFile.createNewFile()
         testFile.writeText(log)
 
-        if (InstrumentationRegistry.getArguments().getString("record") != "true") {
+        if (InstrumentationRegistry.getArguments().getString("record") != "true" && !isTestIgnored) {
             val goldenFile =
                 InstrumentationRegistry.getInstrumentation().context.assets.open(
                     "loggerazzi-golden-files/${testName}.txt"


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-15807](https://jira.tid.es/browse/ANDROID-15807)

### :goal_net: What's the goal?
Add `@IgnoreLoggerazzi` annotation to be able to ignore a test.

### :construction: How do we do it?
* Add `@IgnoreLoggerazzi` annotation.
* Check the annotation in `GenericLoggerazziRule` and don't verify the test if it exists.

### :blue_book: Documentation changes?
- [x] REAME updated

### :test_tube: How can I test this?
- A new example test has been added to check that the test is ignored and it doesn't fail.