### PR TITLE
Just swap recorded and golden line numbers in reports

### DIFF
--- a/loggerazzi/src/main/java/com/telefonica/loggerazzi/LogComparator.kt
+++ b/loggerazzi/src/main/java/com/telefonica/loggerazzi/LogComparator.kt
@@ -9,7 +9,7 @@ interface LogComparator<LogType> {
 class DefaultLogComparator<LogType> : LogComparator<LogType> {
     override fun compare(recorded: List<LogType>, golden: List<LogType>): String? {
         if (recorded.size != golden.size) {
-            return "Different number of lines: recorded=${recorded.size}, golden=${golden.size}"
+            return "Different number of lines: golden=${golden.size}, recorded=${recorded.size}"
         }
 
         val compareResult = StringBuilder()


### PR DESCRIPTION
### :goal_net: What's the goal?
Just swap recorded and golden line numbers in report to match their logs in the final report and avoid my (only me?) TOC with this, were golden logs are listed on the left and record on the right, whereas the message has the opposite order :)

<img width="984" height="158" alt="Screenshot 2025-09-12 at 12 37 06" src="https://github.com/user-attachments/assets/bab39bc3-ad26-4cbb-9fa3-d625c93ea622" />

### :blue_book: Documentation changes?
- [x] No docs to update nor create