### PR TITLE
ANDROID-16807 Add waitForCondition at loggerazzi logs comparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Regular `connectedXXXXAndroidTest` target invocation is enough for verifications
 ./gradlew :app:connectedDebugAndroidTest
 ```
 
+At the end of each test, Loggerazzi compares the recorded logs with the corresponding baseline logs (previously generated in recording mode) allowing up to 5 seconds for the logs to match the expected output.
+
 In case of any failures due logs verifications, regular junit reports include failed tests and comparation failure reason.
 
 Additionally, an specific Loggerazzi report is generated at --> `build/reports/androidTests/connected/debug/loggerazzi/failures.html`


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-16807](https://jira.tid.es/browse/ANDROID-16807)

### :goal_net: What's the goal?
Add some time after test ends to try to wait for logs to be the expected one, if after 5 seconds this still fails, test would be failed.

### :construction: How do we do it?
* Just add a waiting mechanism for logs comparation

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
- [x] Run instrumentation tests inside repository