### PR TITLE
ANDROID-16839 Fix loggerazzi reports

### DIFF
--- a/loggerazzi/src/main/java/com/telefonica/loggerazzi/LoggerazziRule.kt
+++ b/loggerazzi/src/main/java/com/telefonica/loggerazzi/LoggerazziRule.kt
@@ -53,7 +53,6 @@ open class GenericLoggerazziRule<LogType>(
         val testName = "${description?.className}_${description?.methodName}"
         val fileName = "${testName}.${System.nanoTime()}"
 
-        val recordedLogs: List<LogType>
         if (InstrumentationRegistry.getArguments().getString("record") != "true" && !isTestIgnored) {
             val goldenFile =
                 InstrumentationRegistry.getInstrumentation().context.assets.open(
@@ -61,17 +60,19 @@ open class GenericLoggerazziRule<LogType>(
                 )
             val goldenStringLogs = String(goldenFile.readBytes()).takeIf { it.isNotEmpty() }?.split("\n") ?: emptyList()
             val comparison = compare(goldenStringLogs)
+            writeRecordedLogsToFile(fileName, comparison.recordedLogs)
             if (!comparison.success) {
                 val compareFile = File(failuresDir, fileName)
                 compareFile.createNewFile()
                 compareFile.writeText(comparison.failure!!)
                 throw AssertionError("Logs do not match:\n${comparison.failure}")
             }
-            recordedLogs = comparison.recordedLogs
         } else {
-            recordedLogs = recorder.getRecordedLogs()
+            writeRecordedLogsToFile(fileName,recorder.getRecordedLogs())
         }
+    }
 
+    private fun writeRecordedLogsToFile(fileName: String, recordedLogs: List<LogType>) {
         val log = recordedLogs.joinToString("\n") { stringMapper.fromLog(it) }
         val testFile = File(recordedDir, fileName)
         testFile.createNewFile()


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-16839](https://jira.tid.es/browse/ANDROID-16839)

### :goal_net: What's the goal?

We should capture recorded log before crashing the test, if test fails, recorded log wont be generated.

### :construction: How do we do it?
* Capture recorded log correctly

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
- [x] 🖼️ Check reports on failures

<img width="1342" height="422" alt="Captura de pantalla 2025-09-18 a las 9 36 35" src="https://github.com/user-attachments/assets/96eda777-4668-439c-bcef-cf11b25c5066" />


